### PR TITLE
Fix styling for anchor tags in the header

### DIFF
--- a/style.css
+++ b/style.css
@@ -17,6 +17,10 @@ a {
 	text-decoration: none;
 }
 
+header a {
+	color: #0398fc;
+}
+
 .links{
     padding: 0.625rem;
     padding-left: 15px;


### PR DESCRIPTION
The `<a>` tag has the `color: white` style, but that makes it invisible in the header because it has a white background. This PR changes the color of `<a>` tags in the header to blue.